### PR TITLE
variable name conflict

### DIFF
--- a/django-session-idle-timeout/templates/sessionidletimeout/js.html
+++ b/django-session-idle-timeout/templates/sessionidletimeout/js.html
@@ -7,5 +7,5 @@
     }
 
     // ping every five minutes
-    setInterval(session_keep_alive, {{ interval }});
+    setInterval(session_keep_alive, {{ session-keepalive-interval }});
 </script>

--- a/django-session-idle-timeout/templatetags/session_keep_alive.py
+++ b/django-session-idle-timeout/templatetags/session_keep_alive.py
@@ -6,5 +6,5 @@ register = template.Library()
 @register.inclusion_tag('sessionidletimeout/js.html', takes_context=True)
 def session_keep_alive(context):
     return context.update({
-        'interval': int(getattr(settings, 'SESSION_IDLE_TIMEOUT', 1800)) / 2 * 1000,
+        'session-keepalive-interval': int(getattr(settings, 'SESSION_IDLE_TIMEOUT', 1800)) / 2 * 1000,
     })

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     ],
     packages = find_packages(),
     include_package_data=True,
-    version = "1.1.2",
+    version = "1.1.5",
     description = "Timeout a logged user after a period of time",
     long_description=open('README.md').read(-1),
     author = "Tomas Zulberti",


### PR DESCRIPTION
rename interval template variable from "interval" to "session-keepalive-interval" to prevent conflicts.
