### PR TITLE
Session keep alive ping breaks if l10n is on and use_thousands_separator=True

### DIFF
--- a/django-session-idle-timeout/templates/sessionidletimeout/js.html
+++ b/django-session-idle-timeout/templates/sessionidletimeout/js.html
@@ -1,4 +1,5 @@
-{% load url from future l10n %}
+{% load url from future %}
+{% load l10n %}
 <script type="text/javascript">
     function session_keep_alive() {
         http_request = new XMLHttpRequest();

--- a/django-session-idle-timeout/templates/sessionidletimeout/js.html
+++ b/django-session-idle-timeout/templates/sessionidletimeout/js.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from future l10n %}
 <script type="text/javascript">
     function session_keep_alive() {
         http_request = new XMLHttpRequest();
@@ -7,5 +7,5 @@
     }
 
     // ping every five minutes
-    setInterval(session_keep_alive, {{ session_keepalive_interval }});
+    setInterval(session_keep_alive, {{ session_keepalive_interval|unlocalize }});
 </script>

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     ],
     packages = find_packages(),
     include_package_data=True,
-    version = "1.3.1",
+    version = "1.4.2",
     description = "Timeout a logged user after a period of time",
     long_description=open('README.md').read(-1),
     author = "Tomas Zulberti",


### PR DESCRIPTION
Added `unlocalize` template filter to output of variable otherwise the default is outputted as `900,000` which causes the ping back to run every 900ms.

Bumped to 1.4.2 for immediate release on PyPi. Could we get a new release on PyPi?
